### PR TITLE
Update syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var mobiledoc = {
     ]
   ]
 };
-var renderer = new TextRenderer({cards: []});
+var renderer = new TextRenderer.default({cards: []});
 var rendered = renderer.render(mobiledoc);
 console.log(rendered.result); // "hello world"
 ```


### PR DESCRIPTION
Update readme to reflect up-to-date API. When trying to use the renderer without specifying `.default`, I get the following error:

```
Uncaught TypeError: __WEBPACK_IMPORTED_MODULE_4_mobiledoc_text_renderer___default.a is not a constructor

```