### PR TITLE
Use project-specific "broccoli" executable rather than global

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
   - npm config set spin false
 
 install:
-  - npm install -g broccoli-cli
   - npm install
 
 script:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/bustlelabs/mobiledoc-text-renderer",
   "devDependencies": {
     "broccoli": "^1.1.1",
+    "broccoli-cli": "^1.0.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-multi-builder": "^0.3.0",
     "broccoli-test-builder": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,6 +525,13 @@ broccoli-babel-transpiler@^5.6.2:
     rsvp "^3.5.0"
     workerpool "^2.3.0"
 
+broccoli-cli@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-cli/-/broccoli-cli-1.0.0.tgz#69444521a5e631569300fbc196e85e18097b22a4"
+  integrity sha1-aURFIaXmMVaTAPvBluheGAl7IqQ=
+  dependencies:
+    resolve "~0.6.1"
+
 broccoli-concat@^3.2.0:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.7.3.tgz#0dca01311567ffb13180e6b4eb111824628e4885"
@@ -3465,6 +3472,11 @@ resolve@^1.1.6, resolve@^1.10.0:
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
   dependencies:
     path-parse "^1.0.6"
+
+resolve@~0.6.1:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
+  integrity sha1-3ZV5gufnNt699TtYpN2RdUV13UY=
 
 ret@~0.1.10:
   version "0.1.15"


### PR DESCRIPTION
Right now, the developer is required to install broccoli globally to build the project. Instead, `broccoli-cli` is added as a dependency.